### PR TITLE
feat: ScriptUI 対応の entryUI 関数を追加

### DIFF
--- a/.github/skills/add-script/SKILL.md
+++ b/.github/skills/add-script/SKILL.md
@@ -99,7 +99,9 @@ pnpm new -- --app=<appId> --name=<ScriptName> --license
 1. `c:\projects\extendscript-ts-template\.github\instructions\extendscript.instructions.md` を `read_file` で読み込み、コーディングルールを確認する
 2. `purpose` と `@workflow` コメントを元に実装を進める
 3. 実装完了後に `pnpm lint && pnpm format` を実行する
-4. 実装した内容を簡潔に報告する
+4. エラーがなければ `pnpm build -- <appId>/<ScriptName>` を実行してビルドする
+5. エラーがあれば3に戻って修正
+6. エラーがなければ、実装した内容を簡潔に報告する
 
 ## Notes
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 src/lib/polyfills/
 package.json
 pnpm-lock.yaml
+dist/

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 src/lib/polyfills/
-package.json
 pnpm-lock.yaml
-dist/
+dist
+node_modules
+coverage/

--- a/docs/guides/for-beginners.md
+++ b/docs/guides/for-beginners.md
@@ -1,0 +1,443 @@
+# After Effects スクリプトを TypeScript で作ろう【完全初心者ガイド】
+
+> **対象読者**: プログラミング経験ゼロ〜少しある方。After Effects は使えるけど自動化には踏み出せていない方。
+
+---
+
+## はじめに
+
+After Effects で同じ作業を繰り返していませんか？  
+たとえば「選択したレイヤー全部にウィグルをかけたい」とか「100 枚の画像を一括で整列したい」とか。
+
+実は After Effects には **ExtendScript** という自動化の仕組みがあります。  
+しかし ExtendScript は古い JavaScript（ES3）ベースで、そのまま書くのは現代の感覚からすると非常につらい。
+
+このテンプレートを使えば：
+
+- **TypeScript**（モダンな型付き JavaScript）でスクリプトを書ける
+- `Array.map()`、`for...of`、テンプレートリテラルなどの便利な構文が使える
+- **GitHub Copilot**（AI）に「こんなスクリプト書いて」と頼める
+- ビルド一発で After Effects が読める `.jsx` ファイルが出力される
+
+それでは環境構築から始めましょう。
+
+---
+
+## STEP 1: 必要なツールをインストールする
+
+### 1-1. VSCode（エディタ）
+
+コードを書くためのエディタです。無料で使えます。
+
+1. https://code.visualstudio.com/ にアクセス
+2. 「Download for Windows」をクリックしてインストーラをダウンロード
+3. インストーラを実行（すべてデフォルトのままで OK）
+
+インストール後、VSCode を起動して日本語化しておくと使いやすいです：
+
+1. VSCode を開く
+2. 左のサイドバーにある四角いアイコン（Extensions）をクリック
+3. 検索ボックスに「Japanese」と入力
+4. 「Japanese Language Pack for Visual Studio Code」をインストール
+5. VSCode を再起動
+
+---
+
+### 1-2. Git（バージョン管理ツール）
+
+コードの変更履歴を管理するツールです。GitHub と連携するために必要です。
+
+1. https://git-scm.com/ にアクセス
+2. 「Download for Windows」をクリックしてダウンロード
+3. インストーラを実行
+
+> **インストール中の選択肢**: すべてデフォルトのままで問題ありません。
+
+インストール確認：
+
+```bash
+git --version
+# git version 2.x.x と表示されれば OK
+```
+
+---
+
+### 1-3. GitHub CLI（GitHub 操作ツール）
+
+GitHub をコマンドラインから操作するツールです。クローンや認証が楽になります。
+
+1. https://cli.github.com/ にアクセス
+2. 「Download for Windows」をクリック
+3. インストーラを実行（デフォルトのまま）
+
+インストール確認：
+
+```bash
+gh --version
+# gh version x.x.x と表示されれば OK
+```
+
+---
+
+### 1-4. Node.js（JavaScript 実行環境）
+
+ビルドツールを動かすために必要です。バージョン **20 以上**をインストールしてください。
+
+1. https://nodejs.org/ja にアクセス
+2. 「LTS（推奨版）」をクリックしてダウンロード（執筆時点: v22.x）
+3. インストーラを実行（デフォルトのまま）
+
+インストール確認：
+
+```bash
+node --version
+# v22.x.x と表示されれば OK（20以上であればOK）
+```
+
+---
+
+### 1-5. pnpm（パッケージマネージャ）
+
+Node.js のパッケージを管理するツールです。`npm` より高速でディスク容量も節約できます。
+
+Node.js 16.9 以降には **Corepack** というツール管理機能が同梱されています。これを使うのが最も簡単な方法です。
+
+Node.js をインストールした後、コマンドプロンプトまたは PowerShell で：
+
+```bash
+corepack enable pnpm
+```
+
+インストール確認：
+
+```bash
+pnpm --version
+# 10.x.x と表示されれば OK
+```
+
+> **Corepack とは**: Node.js に同梱されたパッケージマネージャ管理ツールです。`npm install -g` と異なり、グローバルインストールなしでパッケージマネージャを切り替えられます。
+
+---
+
+## STEP 2: GitHub アカウントと GitHub Copilot について
+
+### GitHub アカウントを作る
+
+1. https://github.com/join にアクセス
+2. メールアドレス、パスワード、ユーザー名を入力して登録
+3. メール認証を完了させる
+
+---
+
+### 無料プランで GitHub Copilot はどこまで使える？
+
+2025 年現在、GitHub は**無料アカウントでも GitHub Copilot が使えます**。
+
+| 機能 | 無料プラン | Pro プラン（月 $10） |
+|------|----------|---------------------|
+| コード補完（AI インライン提案） | ✅ 月 2,000 回まで | ✅ 無制限 |
+| Copilot Chat（チャット） | ✅ 月 50 回まで | ✅ 無制限 |
+| エージェントモード（自律的なコード生成） | ✅（回数制限内） | ✅ 無制限 |
+| 複数モデル選択（GPT-4o など） | ✅ 一部モデル | ✅ 全モデル |
+
+> **初心者にとって**: 無料プランで十分スタートできます。慣れてきて毎日使うようになったら有料プランを検討しましょう。
+
+---
+
+### GitHub Copilot は VSCode に組み込み済み
+
+VSCode 1.99（2025年3月）以降、**GitHub Copilot は VSCode にデフォルトで組み込まれています**。拡張機能を別途インストールする必要はありません。
+
+ただし、チャット機能を使うには **GitHub アカウントでのサインインが必要**です。
+
+サインイン手順：
+
+1. VSCode 左下のアカウントアイコン（または右下の Copilot アイコン）をクリック
+2. 「Sign in to use GitHub Copilot」をクリック
+3. ブラウザが開くので GitHub アカウントでログイン
+4. VSCode に戻ると Copilot Chat（吹き出しアイコン）が使えるようになる
+
+> **サインインしないと**: コード補完もチャットも使えません。必ずサインインしてから次のステップへ進みましょう。
+
+---
+
+### GitHub CLI でサインインする
+
+後でリポジトリをクローンするために必要です。
+
+```bash
+gh auth login
+```
+
+対話形式で以下を選択します：
+
+```
+? Where do you use GitHub? → GitHub.com
+? What is your preferred protocol for Git operations? → HTTPS
+? Authenticate Git with your GitHub credentials? → Yes
+? How would you like to authenticate GitHub CLI? → Login with a web browser
+```
+
+ブラウザが開くので、表示されるコードを入力して認証を完了させます。
+
+---
+
+## STEP 3: リポジトリを作ってクローンする
+
+### 3-1. テンプレートからリポジトリを作る
+
+1. https://github.com/YukiWorks432/extendscript-ts-template にアクセス
+2. 緑色の「**Use this template**」ボタンをクリック
+3. 「Create a new repository」を選択
+4. リポジトリ名を入力
+
+   > **リポジトリ名のコツ**: このテンプレートは After Effects だけでなく Illustrator・Photoshop など複数のアプリのスクリプトをまとめて管理できます。`my-ae-scripts` のようにアプリ名を入れると後で管理しにくくなるので、`my-adobe-scripts` や `adobe-automation` など**アプリを限定しない名前**にしておくのがおすすめです。
+
+5. Private / Public を選ぶ（どちらでも OK）
+6. 「Create repository」をクリック
+
+これで自分専用のリポジトリが作られました！
+
+---
+
+### 3-2. ローカルにクローンする
+
+作成したリポジトリのページで、クローン用のコマンドをコピーします：
+
+1. リポジトリページの緑色の「**< > Code**」ボタンをクリック
+2. 「**GitHub CLI**」タブを選択
+3. 表示されたコマンド（`gh repo clone ...`）をコピー
+
+```
+例: gh repo clone tanaka/my-adobe-scripts
+```
+
+次に、VSCode のターミナルを開いてコマンドを貼り付けて実行します。
+
+> **ターミナルの開き方**: メニュー「Terminal → New Terminal」、またはショートカット **Ctrl + `**（バッククォート）か **Ctrl + @** でも開けます。  
+> **貼り付けのコツ**: ターミナル内では **右クリック** でペーストできます（Ctrl+V は効かない場合があります）。
+
+クローンが完了したら、フォルダに移動します：
+
+```bash
+cd my-adobe-scripts
+```
+
+---
+
+### 3-3. VSCode で開く
+
+```bash
+code .
+```
+
+これで VSCode がプロジェクトを開きます。
+
+---
+
+## STEP 4: 依存関係をインストールする
+
+VSCode のターミナルを開いてください（**Ctrl + `** または **Ctrl + @**）。
+
+```bash
+pnpm i
+```
+
+数十秒で完了します。これで TypeScript のコンパイラや Rollup（バンドラー）などが使えるようになります。
+
+---
+
+### （オプション）ESLint と Prettier の拡張機能を入れる
+
+コードの品質チェック（ESLint）と自動整形（Prettier）を VSCode で使えるようにしておくと便利です。
+
+1. VSCode の拡張機能パネル（左サイドバーの四角いアイコン）を開く
+2. 以下の 2 つをインストール：
+   - 「**ESLint**」（`dbaeumer.vscode-eslint`）
+   - 「**Prettier - Code formatter**」（`esbenp.prettier-vscode`）
+
+**保存時に自動整形を有効にする**（Ctrl+S で整形）：
+
+VSCode の設定（`Ctrl + ,`）を開き、右上の「**{}**（設定を JSON で開く）」アイコンをクリックして、以下を追加します：
+
+```json
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}
+```
+
+これで TypeScript ファイルを Ctrl+S で保存するたびに自動整形されます。
+
+---
+
+## STEP 5: GitHub Copilot にスクリプトを作ってもらう
+
+このテンプレートには `.github/` フォルダ内に **Copilot 用のスキル定義**が含まれています。これにより、Copilot が「スクリプト追加」の手順を自律的に実行できます。
+
+### 5-1. Copilot Chat に一言頼むだけ
+
+VSCode 左サイドバーの **Copilot Chat**（吹き出しアイコン）を開き、チャットモードを「**Agent**」に切り替えてから、以下のように入力します：
+
+```
+/add-script 選択中のレイヤーの Position にウィグルエクスプレッションを適用するスクリプトを作って
+```
+
+Copilot が自律的に以下をすべてやってくれます：
+
+1. 足りない情報（アプリ・スクリプト名など）を質問してくれる
+2. `pnpm new` でファイルを生成する
+3. スクリプトの実装まで書いてくれる
+
+> **Agent モードとは**: Copilot がファイル操作やターミナルコマンドを自律的に実行するモードです。チャットモードのドロップダウンから「Agent」を選んでください。
+
+---
+
+### 5-2. 生成されるコードの例
+
+Copilot が以下のようなコードを `src/aeft/WiggleApplier/index.ts` に生成します：
+
+```typescript
+// shimを実行するために、initのimportが必須です。
+import "../../init";
+
+import { entry } from "../../lib/lib";
+
+entry("WiggleApplier", () => {
+  const comp = app.project.activeItem;
+  // アクティブなコンポジションが選択されていない場合は終了
+  if (!(comp && comp instanceof CompItem)) {
+    alert("コンポジションを選択してください。");
+    return;
+  }
+
+  const selected = [...comp.selectedLayers];
+  // 選択レイヤーがない場合は終了
+  if (selected.length === 0) {
+    alert("レイヤーを選択してください。");
+    return;
+  }
+
+  // 選択中のすべてのレイヤーにウィグルエクスプレッションを適用
+  for (const layer of selected) {
+    const position = layer.property("ADBE Transform Group")?.property(
+      "ADBE Position"
+    ) as Property | null;
+
+    if (!position) continue;
+
+    // エクスプレッションを設定（wiggle(周波数, 振幅)）
+    position.expression = "wiggle(3, 30)";
+  }
+
+  alert(`${selected.length} 個のレイヤーにウィグルを適用しました。`);
+});
+```
+
+---
+
+### 5-3. コードの意味を理解する
+
+| コード | 意味 |
+|--------|------|
+| `import "../../init"` | ES5/ES6 のポリフィルを読み込む（必須） |
+| `entry("WiggleApplier", () => { ... })` | エラーハンドリングと Undo グループをまとめてくれる便利関数 |
+| `app.project.activeItem` | 現在 After Effects で開いているアイテム |
+| `comp.selectedLayers` | コンポジション内で選択中のレイヤー一覧 |
+| `position.expression = "wiggle(3, 30)"` | エクスプレッションを設定（周波数 3Hz、振幅 30px） |
+
+---
+
+## STEP 6: ビルドする
+
+```bash
+pnpm build
+```
+
+成功すると `dist/aeft/WiggleApplier/WiggleApplier.jsx` が生成されます。
+
+エラーが出た場合は Copilot Chat に「このエラーを修正して」と貼り付けると直してくれます。
+
+---
+
+## STEP 7: After Effects で使う
+
+1. After Effects を起動する
+2. メニューから「**ファイル → スクリプト → スクリプトファイルを実行...**」
+3. 先ほど生成された `dist/aeft/WiggleApplier/WiggleApplier.jsx` を選択
+4. コンポジションでレイヤーを選択した状態でスクリプトを実行
+5. 選択したレイヤーの Position にウィグルエクスプレッションが適用されます！
+
+> **毎回メニューから選ぶのが面倒な場合**:  
+> `WiggleApplier.jsx` を After Effects の `Scripts/ScriptUI Panels/` フォルダにコピーすると、メニューに常駐させることもできます。
+
+---
+
+## よくあるエラーと対処法
+
+### `pnpm: コマンドが見つかりません`
+
+Node.js のインストール後にターミナルを再起動してから、再度 `corepack enable pnpm` を実行してみてください。  
+それでもダメなら管理者権限でコマンドプロンプトを開いて実行してください。
+
+### ビルドエラー: `TS2339: Property 'xxx' does not exist`
+
+型定義が不足しているサインです。Copilot Chat に「このエラーを型アサーションで回避して」と頼んでみてください。  
+または `as any` を一時的に付けてビルドを通すことができます。
+
+### After Effects でスクリプトを実行しても何も起きない
+
+- コンポジションが開かれているか確認
+- レイヤーが選択されているか確認
+- After Effects のメニュー「編集 → 環境設定 → スクリプトとエクスプレッション」で「スクリプトによるファイルおよびネットワークへのアクセスを許可」にチェックが入っているか確認
+
+### `gh repo clone` でエラーが出る
+
+`gh auth login` でログインできているか確認してください：
+
+```bash
+gh auth status
+```
+
+---
+
+## 次のステップ
+
+環境構築とスクリプト作成ができたら、次はこんなことを試してみましょう：
+
+- **複数のスクリプトを管理する**: `pnpm new` でどんどんスクリプトを追加できます
+- **共通処理をライブラリ化する**: `src/aeft/lib/lib.ts` に共通関数をまとめられます
+- **Illustrator / Photoshop 向けも作る**: `--app=ilst` や `--app=phxs` で他アプリ向けも同じ手順で作れます
+- **VSCode の推奨拡張機能を使う**:
+  - [ExtendScript Debugger](https://marketplace.visualstudio.com/items?itemName=Adobe.extendscript-debug): スクリプトを VSCode からデバッグ実行できる（Adobe 公式）
+  - [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint): コードの問題をリアルタイムで検出
+  - [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode): コードを自動整形
+
+---
+
+## まとめ
+
+| やったこと | コマンド |
+|-----------|---------|
+| 環境構築 | VSCode / Git / GitHub CLI / Node.js / pnpm をインストール |
+| リポジトリ作成 | GitHub の Use this template → Code > GitHub CLI → `gh repo clone` |
+| 依存関係インストール | `pnpm i` |
+| スクリプト作成（AI） | Copilot Chat（Agent モード）で `/add-script ...` と入力 |
+| ビルド | `pnpm build` |
+| AE で実行 | ファイル → スクリプト → スクリプトファイルを実行... |
+
+このテンプレートを使えば「コードは書けないけど After Effects の自動化はしたい」という方でも、AI の力を借りて実用的なスクリプトを作れます。  
+
+ぜひ自分の作業フローを自動化してみてください！
+
+---
+
+## 参考リンク
+
+- [extendscript-ts-template](https://github.com/YukiWorks432/extendscript-ts-template) - このテンプレートの GitHub リポジトリ
+- [Types-for-Adobe](https://github.com/docsforadobe/Types-for-Adobe) - Adobe アプリの型定義（有志作成）
+- [After Effects スクリプティングガイド](https://ae-scripting.docsforadobe.dev/) - AE のオブジェクト・メソッド一覧（英語）
+- [GitHub Copilot の無料プランについて](https://docs.github.com/ja/copilot/about-github-copilot/subscription-plans-for-github-copilot) - 公式ドキュメント

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -94,7 +94,38 @@ src/aeft/
 
 ### 共通ユーティリティを使う
 
-`src/lib/lib.ts` に `entry()` や `alertError()` など全アプリ共通のユーティリティがある。
+`src/lib/lib.ts` に `entry()`、`entryUI()`、`alertError()` など全アプリ共通のユーティリティがある。
+
+```ts
+import { entry, entryUI, alertError } from "../../lib/lib";
+```
+
+#### `entry` — 通常スクリプト用
+
+```ts
+entry("MyScript", () => {
+  // 処理を書く
+});
+```
+
+#### `entryUI` — ScriptUI パネル対応スクリプト用
+
+ドッキングパネルとして使う場合は `entryUI` と `__ES_THIS__` を使う。
+`__ES_THIS__` はビルド時にバンドル先頭へ自動注入されるグローバルな `this`。
+
+```ts
+import { entryUI } from "../../lib/lib";
+
+entryUI("MyScript", __ES_THIS__, (win) => {
+  win.add("statictext", undefined, "Hello, ScriptUI!");
+  // win は Panel（パネル起動時）または Window（スクリプト直接実行時）
+});
+```
+
+| 起動方法 | `__ES_THIS__` の値 | `entryUI` の動作 |
+|---------|-------------------|------------------|
+| スクリプトとして実行 | グローバルオブジェクト | `new Window("palette")` を生成して表示 |
+| ドッキングパネルとして起動 | `Panel` | 渡された `Panel` をそのまま使用 |
 
 ```ts
 import { entry, alertError } from "../../lib/lib";

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -17,9 +17,9 @@ src/                       # ソースコード
   init.ts                  # ポリフィル読み込みエントリ（全スクリプトで import 必須）
   lib/                     # 全アプリ共通ライブラリ
     polyfills/             # ES5/ES6/ESNext ポリフィル
-    lib.ts                 # 汎用ユーティリティ（entry, alertError）
+    lib.ts                 # 汎用ユーティリティ（entry, entryUI, alertError）
   types/                   # 全アプリ共通の型定義
-    index.d.ts             # Error, Application 拡張
+    index.d.ts             # Error, Application 拡張、__ES_THIS__ グローバル変数
   tests/                   # ポリフィルテスト（アプリ非依存）
   aeft/                    # After Effects 向けスクリプト
     tsconfig.json          # AE 用 TypeScript 設定（types-for-adobe/AfterEffects）
@@ -118,6 +118,22 @@ entry("MyScript", () => {
   // TODO: Implement MyScript
 });
 ```
+
+**ScriptUI スクリプト（パネル対応）を作る場合は `entryUI` を使う：**
+
+```ts
+import "../../init";
+import { entryUI } from "../../lib/lib";
+
+entryUI("MyScript", __ES_THIS__, (win) => {
+  win.add("statictext", undefined, "Hello!");
+  // ここで UI を構築する
+});
+```
+
+`__ES_THIS__` はビルド時にバンドル先頭へ自動注入されるグローバルな `this` で、
+Extension Manager / Dockable パネルとして起動された場合は `Panel`、
+スクリプトとして実行された場合はグローバルオブジェクトを返す。
 
 ### 予約名
 

--- a/es.config.mjs
+++ b/es.config.mjs
@@ -5,6 +5,12 @@ export default {
   scripts: {
     aeft: [
       {
+        name: "AddWiggle",
+        version: "0.0.1",
+        build: true,
+        license: true,
+      },
+      {
         name: "example",
         version: "0.0.1",
         build: true,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "watch": "rollup -c -w",
     "lint": "eslint src/**/*.ts",
     "format": "prettier --write src/**/*.ts",
-    "new": "node ./scripts/newScript.mjs",
+    "new": "node ./scripts/newScript.mjs&&prettier --write ./es.config.mjs",
     "add-app": "node ./scripts/addApp.mjs"
   },
   "keywords": [

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -287,7 +287,7 @@ export default (commandLineArgs) => {
       const fileHash =
         currentBuildHashes[hashKey] || calculateFileHash(inputFile);
 
-      const banner = `/** ${script.name} v${script.version} hash: ${fileHash} */`;
+      const banner = `/** ${script.name} v${script.version} hash: ${fileHash} */\nvar __ES_THIS__=this;`;
 
       return {
         input: inputFile,

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -154,7 +154,7 @@ const terserConfig = (preamble) =>
       passes: 1,
     },
     format: {
-      comments: /(@preserve)/,
+      comments: /(@preserve|@description)/,
       preamble,
     },
   });
@@ -190,7 +190,6 @@ const createBabelConfig = () =>
     extensions,
     babelrc: false,
     babelHelpers: "bundled",
-    comments: false,
     presets: [
       [
         "@babel/preset-env",

--- a/src/aeft/lib/lib.ts
+++ b/src/aeft/lib/lib.ts
@@ -1,0 +1,279 @@
+/***
+ * After Effects ユーティリティ関数
+ */
+
+/**
+ * AVLayerのpositionプロパティの値を3次元配列で取得する
+ */
+export const getPosition = (layer: AVLayer): [number, number, number] => {
+  if (layer.position.separationDimension) {
+    if (layer.threeDLayer) {
+      return [
+        layer.transform.xPosition.value,
+        layer.transform.yPosition.value,
+        layer.transform.zPosition.value,
+      ];
+    }
+    return [
+      layer.transform.xPosition.value,
+      layer.transform.yPosition.value,
+      0,
+    ];
+  }
+
+  if (layer.threeDLayer) {
+    return layer.position.value as [number, number, number];
+  }
+
+  const v = layer.position.value as [number, number];
+  return [v[0], v[1], 0];
+};
+
+/**
+ * Layer が AVLayer かどうかを判定する.
+ */
+export const isAVLayer = (layer: Layer): layer is AVLayer => {
+  return (
+    layer instanceof AVLayer ||
+    layer instanceof ShapeLayer ||
+    layer instanceof TextLayer
+  );
+};
+
+/**
+ * Layer が TextLayer かどうかを判定する.
+ */
+export const isTextLayer = (layer: Layer): layer is TextLayer => {
+  return layer instanceof TextLayer;
+};
+
+/**
+ * Layer が ShapeLayer かどうかを判定する.
+ */
+export const isShapeLayer = (layer: Layer): layer is ShapeLayer => {
+  return layer instanceof ShapeLayer;
+};
+
+declare interface CompLayer extends AVLayer {
+  readonly source: CompItem;
+}
+/**
+ * Layer が CompItem をソースに持つ AVLayer かどうかを判定する.
+ */
+export const isCompLayer = (layer: Layer): layer is CompLayer => {
+  return isAVLayer(layer) && layer.source instanceof CompItem;
+};
+
+/**
+ * Item が CompItem かどうかを判定する.
+ */
+export const isCompItem = (item: _ItemClasses | null): item is CompItem => {
+  return item instanceof CompItem;
+};
+
+/**
+ * _PropertyClasses が PropertyGroup かどうかを判定する.
+ */
+export const isPropertyGroup = (
+  prop: _PropertyClasses
+): prop is PropertyGroup => {
+  return prop instanceof PropertyGroup;
+};
+
+/**
+ * _PropertyClasses が Property かどうかを判定する.
+ */
+export const isProperty = (prop: _PropertyClasses): prop is Property => {
+  return prop instanceof Property;
+};
+
+/**
+ * property が Fill か判定する.
+ */
+export const isFillProperty = (prop: _PropertyClasses): prop is Fill => {
+  return prop.matchName === "ADBE Vector Graphic - Fill";
+};
+
+/**
+ * property が Gradient Fill か判定する.
+ */
+export const isGradientFillProperty = (
+  prop: _PropertyClasses
+): prop is GradientFill => {
+  return prop.matchName === "ADBE Vector Graphic - G-Fill";
+};
+
+/**
+ * property が Stroke か判定する.
+ */
+export const isStrokeProperty = (prop: _PropertyClasses): prop is Stroke => {
+  return prop.matchName === "ADBE Vector Graphic - Stroke";
+};
+
+/**
+ * shape に Fill プロパティを追加する.
+ */
+export const addFillProperty = (shape: PropertyGroup): Fill => {
+  if (!shape.canAddProperty("ADBE Vector Graphic - Fill")) {
+    throw new Error("Cannot add Fill property to the shape");
+  }
+  const fill = shape.addProperty("ADBE Vector Graphic - Fill");
+  if (isFillProperty(fill)) {
+    return fill;
+  }
+  throw new Error("Failed to add Fill property to the shape");
+};
+
+/**
+ * GradientFill プロパティに値を適用する.
+ * @param target 値を適用する GradientFill プロパティ
+ * @param source 値のコピー元となる GradientFill プロパティ
+ * @throws 値の適用に失敗した場合にエラーをスローする
+ */
+export const applyGradientFillProperty = (
+  target: GradientFill,
+  source: GradientFill
+) => {
+  try {
+    target.type.setValue(source.type.value);
+    target.startPoint.setValue(source.startPoint.value);
+    target.endPoint.setValue(source.endPoint.value);
+    target.highlightLength?.setValue(
+      source.highlightLength?.value ?? target.highlightLength?.value ?? 0
+    );
+    target.highlightAngle?.setValue(
+      source.highlightAngle?.value ?? target.highlightAngle?.value ?? 0
+    );
+    target.scale.setValue(source.scale.value);
+    target.rotation.setValue(source.rotation.value);
+    target.colors.setValue(source.colors.value);
+    target.opacity.setValue(source.opacity.value);
+  } catch (e) {
+    throw new Error("Failed to copy Gradient Fill properties: " + e);
+  }
+};
+
+/**
+ * shape に Gradient Fill プロパティを追加する.
+ * @param shape Gradient Fill プロパティを追加する PropertyGroup
+ * @param gradient 値のコピー元となる GradientFill プロパティ (省略した場合は追加したプロパティの初期値がコピーされる)
+ * @returns 追加された Gradient Fill プロパティ
+ * @throws Gradient Fill プロパティの追加に失敗した場合にエラーをスローする
+ */
+export const addGradientFillProperty = (
+  shape: PropertyGroup,
+  gradient?: GradientFill
+): GradientFill => {
+  if (!shape.canAddProperty("ADBE Vector Graphic - G-Fill")) {
+    throw new Error("Cannot add Gradient Fill property to the shape");
+  }
+  const fill = shape.addProperty("ADBE Vector Graphic - G-Fill");
+  if (isGradientFillProperty(fill)) {
+    applyGradientFillProperty(fill, gradient ?? fill);
+    return fill;
+  }
+  throw new Error("Failed to add Gradient Fill property to the shape");
+};
+
+/**
+ * shape に Stroke プロパティを追加する.
+ */
+export const addStrokeProperty = (shape: PropertyGroup): Stroke => {
+  if (!shape.canAddProperty("ADBE Vector Graphic - Stroke")) {
+    throw new Error("Cannot add Stroke property to the shape");
+  }
+  const stroke = shape.addProperty("ADBE Vector Graphic - Stroke");
+  if (isStrokeProperty(stroke)) {
+    return stroke;
+  }
+  throw new Error("Failed to add Stroke property to the shape");
+};
+
+export const layerCollectionToArray = (
+  collection: LayerCollection
+): Layer[] => {
+  const layers: Layer[] = [];
+  for (let i = 1; i <= collection.length; i++) {
+    layers.push(collection[i]);
+  }
+  return layers;
+};
+
+export const layersInOut = (
+  layers: Layer[]
+): { inPoint: number; outPoint: number } => {
+  let inPoint = Number.NEGATIVE_INFINITY;
+  let outPoint = Number.POSITIVE_INFINITY;
+
+  for (const layer of layers) {
+    if (layer.inPoint > inPoint) {
+      inPoint = layer.inPoint;
+    }
+    if (layer.outPoint < outPoint) {
+      outPoint = layer.outPoint;
+    }
+  }
+
+  return { inPoint, outPoint };
+};
+
+export const addSolidLayer = (width: number, height: number) => {
+  const proj = app.project;
+  const comp = app.project.activeItem;
+  if (!isCompItem(comp)) {
+    throw new Error("No active composition");
+  }
+  const solidName = `Solid (${width}x${height})`;
+  const existing = findWhiteSolidFootage(proj, solidName, width, height);
+  if (existing) {
+    return comp.layers.add(existing);
+  }
+  return comp.layers.addSolid([1, 1, 1], solidName, width, height, 1);
+};
+
+export const addAdjustmentLayer = (width: number, height: number) => {
+  const proj = app.project;
+  const comp = app.project.activeItem;
+  if (!isCompItem(comp)) {
+    throw new Error("No active composition");
+  }
+  const solidName = `Solid (${width}x${height})`;
+
+  let layer: AVLayer | null = null;
+  const existing = findWhiteSolidFootage(proj, solidName, width, height);
+  if (existing) {
+    layer = comp.layers.add(existing);
+  } else {
+    layer = comp.layers.addSolid([1, 1, 1], solidName, width, height, 1);
+  }
+
+  layer.adjustmentLayer = true;
+  layer.label = 5;
+  layer.name = "Adjustment Layer";
+
+  return layer;
+};
+
+const findWhiteSolidFootage = (
+  project: Project,
+  solidName: string,
+  width: number,
+  height: number
+): FootageItem | null => {
+  for (let i = 1, l = project.numItems; i <= l; i++) {
+    const item = project.item(i);
+    if (
+      item instanceof FootageItem &&
+      item.mainSource instanceof SolidSource &&
+      item.name.indexOf(solidName) === 0 &&
+      item.width === width &&
+      item.height === height &&
+      item.mainSource.color[0] === 1 &&
+      item.mainSource.color[1] === 1 &&
+      item.mainSource.color[2] === 1
+    ) {
+      return item;
+    }
+  }
+  return null;
+};

--- a/src/aeft/types/index.d.ts
+++ b/src/aeft/types/index.d.ts
@@ -1,2 +1,36 @@
 // jp: After Effects 固有の型定義を記述するファイルです。
 // en: Type definitions specific to After Effects.
+
+declare class Fill extends PropertyGroup {
+  readonly composite: Property<OneDType>;
+  readonly fillRule: Property<OneDType>;
+  readonly color: Property<ColorType>;
+  readonly opacity: Property<OneDType>;
+}
+
+declare class GradientFill extends PropertyGroup {
+  readonly composite: Property<OneDType>;
+  readonly fillRule: Property<OneDType>;
+  readonly type: Property<OneDType>;
+  readonly startPoint: Property<TwoD_SPATIAL>;
+  readonly endPoint: Property<TwoD_SPATIAL>;
+  readonly highlightLength?: Property<OneDType>;
+  readonly highlightAngle?: Property<OneDType>;
+  readonly scale: Property<TwoDType>;
+  readonly rotation: Property<OneDType>;
+  readonly colors: Property<NoValueType>;
+  readonly opacity: Property<OneDType>;
+}
+
+declare class Stroke extends PropertyGroup {
+  readonly composite: Property<OneDType>;
+  readonly color: Property<ColorType>;
+  readonly opacity: Property<OneDType>;
+  readonly strokeWidth: Property<OneDType>;
+  readonly lineCap: Property<OneDType>;
+  readonly lineJoin: Property<OneDType>;
+  readonly miterLimit: Property<OneDType>;
+  readonly dash: PropertyGroup;
+  readonly taper: PropertyGroup;
+  readonly wave: PropertyGroup;
+}

--- a/src/ilst/lib/lib.ts
+++ b/src/ilst/lib/lib.ts
@@ -1,0 +1,48 @@
+/***
+ * Illustrator ユーティリティ関数
+ */
+
+export const isGroupItem = (item: PageItem): item is GroupItem => {
+  return item.typename === "GroupItem";
+};
+
+export const isCompoundPathItem = (
+  item: PageItem
+): item is CompoundPathItem => {
+  return item.typename === "CompoundPathItem";
+};
+
+export const isTextFrame = (item: PageItem): item is TextFrame => {
+  return item.typename === "TextFrame";
+};
+
+export const isLayer = (item: PageItem | Layer): item is Layer => {
+  return item.typename === "Layer";
+};
+
+export const isArtboard = (item: any): item is Artboard => {
+  return item.typename === "Artboard";
+};
+
+export const isPathItem = (item: PageItem): item is PathItem => {
+  return item.typename === "PathItem";
+};
+
+/***
+ * jp: groupをアートボード上の中央に配置する.\
+ * en: Center the group on the artboard.
+ */
+export const centerGroupInArtboard = (artboard: Artboard, group: GroupItem) => {
+  const abRect = artboard.artboardRect; // [left, top, right, bottom]
+  const abCenterX = (abRect[0] + abRect[2]) / 2;
+  const abCenterY = (abRect[1] + abRect[3]) / 2;
+
+  const groupBounds = group.visibleBounds; // [left, top, right, bottom]
+  const groupCenterX = (groupBounds[0] + groupBounds[2]) / 2;
+  const groupCenterY = (groupBounds[1] + groupBounds[3]) / 2;
+
+  const deltaX = abCenterX - groupCenterX;
+  const deltaY = abCenterY - groupCenterY;
+
+  group.translate(deltaX, deltaY);
+};

--- a/src/ilst/types/index.d.ts
+++ b/src/ilst/types/index.d.ts
@@ -1,2 +1,29 @@
 // jp: Illustrator 固有の型定義を記述するファイルです。
 // en: Type definitions specific to Illustrator.
+
+/**
+ * Location to move element to.
+ * @see https://ai-scripting.docsforadobe.dev/jsobjref/scripting-constants/?h=elementplacement#elementplacement
+ */
+declare enum ElementPlacement {
+  /**
+   * Inside
+   */
+  INSIDE = "INSIDE",
+  /**
+   * Place After
+   */
+  PLACEAFTER = "PLACEAFTER",
+  /**
+   * Place At Beginning
+   */
+  PLACEATBEGINNING = "PLACEATBEGINNING",
+  /**
+   * Place At End
+   */
+  PLACEATEND = "PLACEATEND",
+  /**
+   * Place Before
+   */
+  PLACEBEFORE = "PLACEBEFORE",
+}

--- a/src/lib/lib.ts
+++ b/src/lib/lib.ts
@@ -49,3 +49,36 @@ export const entry = (name: string, func: () => any) => {
 
   if (app.endUndoGroup) app.endUndoGroup();
 };
+
+/***
+ * jp: Scripts UI 対応の entry 関数。\
+ *     Panel として起動された場合はそのまま使用し、そうでない場合は palette Window を生成して表示する.\
+ * en: Entry function for ScriptUI.\
+ *     Uses the provided Panel when launched as a dockable panel, otherwise creates and shows a palette Window.
+ * @example
+ * entryUI("My Script", __ES_THIS__, (win) => {
+ *   win.add("statictext", undefined, "Hello, ScriptUI!");
+ * });
+ */
+export const entryUI = (
+  name: string,
+  thisObj: object,
+  func: (win: Window | Panel) => void
+): void => {
+  var win: Window | Panel;
+  if (thisObj instanceof Panel) {
+    win = thisObj;
+  } else {
+    win = new Window("palette", name);
+  }
+
+  try {
+    func(win);
+  } catch (e) {
+    alertError(e as Error);
+  }
+
+  if (win instanceof Window) {
+    win.show();
+  }
+};

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -7,6 +7,14 @@ interface Error {
 
 // jp: ExtendScript環境のApplicationオブジェクトに存在する可能性のあるメソッドを型定義に追加します。
 // en: Add methods that may exist on the Application object in the ExtendScript environment to the type definition.
+/**
+ * jp: バンドル時にスクリプト先頭へ注入されるグローバルな this。\
+ *     ScriptUI パネルとして起動された場合は Panel、そうでない場合はグローバルオブジェクト。\
+ * en: Global `this` injected at the top of the bundle.\
+ *     Holds the Panel when launched as a ScriptUI panel, otherwise the global object.
+ */
+declare var __ES_THIS__: object;
+
 interface Application {
   /**
    * jp: Undoグループ化を開始するメソッド。Aeの場合のみ存在します。\


### PR DESCRIPTION
## 概要

ScriptUI パネルとしても通常スクリプトとしても動作する `entryUI` 関数を追加。  
バンドル時にグローバルな `this`（`__ES_THIS__`）を先頭へ自動注入することで、Extension Manager のドッキングパネルと通常実行の両方に対応する。

## 変更内容

### `src/lib/lib.ts`
- `entryUI(name, thisObj, func)` 関数を追加
  - `thisObj instanceof Panel` の場合はその Panel をそのまま使用
  - それ以外は `new Window("palette", name)` を生成して `show()`

### `rollup.config.mjs`
- ビルド出力の preamble に `var __ES_THIS__=this;` を追加
  - スクリプト先頭でグローバルな `this` をキャプチャすることで、Panel / グローバルオブジェクトを正しく参照できる

### `src/types/index.d.ts`
- `declare var __ES_THIS__: object;` を追加して TypeScript で参照可能にする

### `docs/`
- `project-overview.md`・`getting-started.md` を `entryUI` / `__ES_THIS__` の説明で更新

## 使い方

```ts
import "../../init";
import { entryUI } from "../../lib/lib";

entryUI("My Script", __ES_THIS__, (win) => {
  win.add("statictext", undefined, "Hello, ScriptUI!");
});
```

| 起動方法 | `__ES_THIS__` | `entryUI` の動作 |
|---------|---------------|-----------------|
| スクリプトとして実行 | グローバルオブジェクト | `new Window("palette")` を生成・表示 |
| ドッキングパネルとして起動 | `Panel` | 渡された Panel をそのまま使用 |