### PR TITLE
Add dependabot configuration for npm package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      timezone: "Asia/Tokyo"
+      time: "10:00"
+    target-branch: "develop"


### PR DESCRIPTION
Introduce a dependabot.yml file to schedule weekly updates for npm packages on Mondays at 10:00 AM JST, targeting the develop branch.