### PR TITLE
リリース自動化を追加

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,223 @@
+name: release
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Version bump type.
+        required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      notes:
+        description: Release notes. Optional.
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: read
+
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Create release
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Determine release settings
+        id: settings
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MANUAL_BUMP: ${{ inputs.bump }}
+          MANUAL_NOTES: ${{ inputs.notes }}
+          PR_LABELS_JSON: ${{ toJson(github.event.pull_request.labels.*.name) }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          node <<'NODE'
+          const fs = require("fs");
+
+          const eventName = process.env.EVENT_NAME;
+          const outputPath = process.env.GITHUB_OUTPUT;
+          const summaryPath = process.env.GITHUB_STEP_SUMMARY;
+          const labels = JSON.parse(process.env.PR_LABELS_JSON || "[]");
+
+          let shouldRelease = true;
+          let bump = "patch";
+          let notes = "";
+          let syncDevelop = false;
+
+          if (eventName === "workflow_dispatch") {
+            bump = process.env.MANUAL_BUMP || "patch";
+            notes = process.env.MANUAL_NOTES || "手動実行によるリリースです。";
+          } else {
+            syncDevelop =
+              process.env.PR_HEAD_REF === "develop" &&
+              process.env.PR_HEAD_REPO === process.env.REPOSITORY;
+
+            if (labels.includes("release:none")) {
+              shouldRelease = false;
+            }
+
+            const releaseLabels = labels.filter((label) => /^release:(major|minor|patch)$/.test(label));
+            if (releaseLabels.includes("release:major")) {
+              bump = "major";
+            } else if (releaseLabels.includes("release:minor")) {
+              bump = "minor";
+            } else if (releaseLabels.includes("release:patch")) {
+              bump = "patch";
+            }
+
+            const prNumber = process.env.PR_NUMBER;
+            const prTitle = process.env.PR_TITLE || "";
+            const prBody = process.env.PR_BODY || "";
+            notes = [
+              `main へマージされた PR #${prNumber} から作成したリリースです。`,
+              "",
+              `## PR`,
+              `- #${prNumber} ${prTitle}`,
+              "",
+              prBody.trim() ? `## Notes\n${prBody.trim()}` : "",
+            ]
+              .filter(Boolean)
+              .join("\n");
+          }
+
+          fs.appendFileSync(outputPath, `should_release=${shouldRelease}\n`);
+          fs.appendFileSync(outputPath, `sync_develop=${syncDevelop}\n`);
+          fs.appendFileSync(outputPath, `bump=${bump}\n`);
+          fs.writeFileSync("release-notes.md", notes);
+          fs.appendFileSync(summaryPath, `release: ${shouldRelease}\n\nbump: ${bump}\n\nsync develop: ${syncDevelop}\n`);
+          NODE
+
+      - name: Set up Node.js
+        if: steps.settings.outputs.should_release == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Bump package version
+        if: steps.settings.outputs.should_release == 'true'
+        id: version
+        env:
+          BUMP: ${{ steps.settings.outputs.bump }}
+        run: |
+          node <<'NODE'
+          const fs = require("fs");
+
+          const bump = process.env.BUMP;
+          const outputPath = process.env.GITHUB_OUTPUT;
+          const packagePath = "package.json";
+          const pkg = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+          const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(pkg.version);
+
+          if (!match) {
+            throw new Error(`Unsupported package version: ${pkg.version}`);
+          }
+
+          let major = Number(match[1]);
+          let minor = Number(match[2]);
+          let patch = Number(match[3]);
+
+          if (bump === "major") {
+            major += 1;
+            minor = 0;
+            patch = 0;
+          } else if (bump === "minor") {
+            minor += 1;
+            patch = 0;
+          } else if (bump === "patch") {
+            patch += 1;
+          } else {
+            throw new Error(`Unsupported bump type: ${bump}`);
+          }
+
+          const nextVersion = `${major}.${minor}.${patch}`;
+          pkg.version = nextVersion;
+          fs.writeFileSync(packagePath, `${JSON.stringify(pkg, null, 2)}\n`);
+          fs.appendFileSync(outputPath, `version=${nextVersion}\n`);
+          fs.appendFileSync(outputPath, `tag=v${nextVersion}\n`);
+          NODE
+
+      - name: Verify tag does not exist
+        if: steps.settings.outputs.should_release == 'true'
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git fetch --tags origin
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag already exists: $TAG" >&2
+            exit 1
+          fi
+
+      - name: Commit version and create local tag
+        if: steps.settings.outputs.should_release == 'true'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add package.json
+          git commit -m "chore: v${VERSION} をリリース"
+          git tag -a "$TAG" -m "$TAG"
+
+      - name: Verify develop can be fast-forwarded
+        if: steps.settings.outputs.should_release == 'true' && steps.settings.outputs.sync_develop == 'true'
+        run: |
+          git fetch origin develop
+          if ! git merge-base --is-ancestor origin/develop HEAD; then
+            echo "develop をリリースコミットへ早送りできません。" >&2
+            echo "develop から main への PR は merge commit でマージしてください。" >&2
+            exit 1
+          fi
+
+      - name: Push release commit and tag
+        if: steps.settings.outputs.should_release == 'true'
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          SYNC_DEVELOP: ${{ steps.settings.outputs.sync_develop }}
+        run: |
+          git push origin HEAD:main
+          if [ "$SYNC_DEVELOP" = "true" ]; then
+            git push origin HEAD:develop
+          fi
+          git push origin "$TAG"
+
+      - name: Create GitHub Release
+        if: steps.settings.outputs.should_release == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          gh release create "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "$TAG" \
+            --notes-file release-notes.md
+
+      - name: Report skipped release
+        if: steps.settings.outputs.should_release != 'true'
+        run: |
+          echo "release:none が付いているため、リリース作成をスキップしました。" >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -144,3 +144,4 @@ pnpm watch
 - [プロジェクト概要](docs/project-overview.md)
 - [ポリフィル](docs/polyfills.md)
 - [はじめに](docs/guides/getting-started.md)
+- [リリース手順](docs/release-process.md)

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,74 @@
+# リリース手順
+
+このリポジトリでは、`main` に Pull Request をマージしたときに GitHub Actions がリリースを作成します。
+
+## 自動リリース
+
+`main` 向け Pull Request がマージされると、`.github/workflows/release.yml` が動きます。
+
+ワークフローは以下を自動で行います。
+
+1. `package.json` の `version` を更新
+2. `chore: vX.Y.Z をリリース` コミットを `main` に追加
+3. `vX.Y.Z` の注釈付きタグを作成
+4. GitHub Release を作成
+5. `develop` から `main` へマージした場合は、同じリリースコミットを `develop` にも早送り反映
+
+`pnpm-lock.yaml` にはこのリポジトリ自身の `version` が含まれないため、通常は更新されません。
+
+## バージョンの決まり方
+
+Pull Request に付けたラベルで、上げるバージョンを決めます。
+
+| ラベル          | 動作               |
+| --------------- | ------------------ |
+| `release:major` | `X.0.0` へ上げる   |
+| `release:minor` | `0.X.0` へ上げる   |
+| `release:patch` | `0.0.X` へ上げる   |
+| `release:none`  | リリースを作らない |
+
+`release:*` ラベルがない場合は `release:patch` として扱います。
+
+複数のリリースラベルが付いた場合は、`major`、`minor`、`patch` の順で大きいものを採用します。
+
+## Pull Request の作り方
+
+通常の変更は feature ブランチで行い、`develop` に squash merge します。
+リリースするまとまりになったら、`develop` から `main` へ Pull Request を作ります。
+`develop` から `main` への Pull Request は、squash merge ではなく merge commit でマージしてください。
+これにより、リリースコミットを `develop` にも安全に早送りできます。
+
+例:
+
+```text
+feature/add-script-ui -> develop -> main
+```
+
+`main` 向け Pull Request には、変更の大きさに応じてラベルを付けます。
+
+- 互換性を壊す変更: `release:major`
+- 機能追加: `release:minor`
+- 修正やドキュメント更新: `release:patch`
+- リリース不要の管理変更: `release:none`
+
+## 手動リリース
+
+GitHub Actions の `release` ワークフローは手動実行もできます。
+
+手動実行では `bump` に `major`、`minor`、`patch` のいずれかを指定します。
+`notes` を入力した場合は、その内容が GitHub Release の本文になります。
+手動実行では `develop` への自動同期は行いません。
+
+## 事前設定
+
+GitHub Actions が `main` へリリースコミットを push し、タグと Release を作れる必要があります。
+
+リポジトリの Actions 設定で `GITHUB_TOKEN` に書き込み権限を許可してください。
+`main` にブランチ保護を設定している場合は、GitHub Actions の push を許可するか、リリース用の例外を設定してください。
+
+## 失敗した場合
+
+ワークフローがタグ作成後、Release 作成前に失敗した場合は、同じタグ名で Release を手動作成してください。
+
+ワークフローが `main` への push に失敗した場合は、別のリリース処理が先に `main` を進めた可能性があります。
+その場合は `main` を確認し、必要なら新しい Pull Request で再実行してください。


### PR DESCRIPTION
## 概要
- main 向け PR マージ時に package.json の version 更新、タグ作成、GitHub Release 作成を自動化します。
- release:major / release:minor / release:patch / release:none ラベルでリリース種別を制御します。
- develop から main へ merge commit でマージした場合は、リリースコミットを develop にも早送り同期します。
- docs/release-process.md に運用手順を追加しました。

## 検証
- pnpm install --frozen-lockfile
- pnpm format
- pnpm lint
- pnpm build