### PR TITLE
[codex] 共通依存をビルドハッシュに含める

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -40,32 +40,57 @@ const hashText = (text) => {
   return hashSum.digest("hex");
 };
 
-const collectTypeScriptFiles = (targetDir) => {
-  if (!fs.existsSync(targetDir)) {
+const normalizePath = (filePath) => filePath.replace(/\\/g, "/");
+
+const collectFiles = (targetPath) => {
+  if (!fs.existsSync(targetPath)) {
     return [];
   }
 
-  const entries = fs.readdirSync(targetDir, { withFileTypes: true });
+  const stats = fs.statSync(targetPath);
+  if (stats.isFile()) {
+    return [path.resolve(targetPath)];
+  }
+
+  if (!stats.isDirectory()) {
+    return [];
+  }
+
+  const entries = fs.readdirSync(targetPath, { withFileTypes: true });
   const files = [];
 
   entries.forEach((entry) => {
-    const fullPath = path.join(targetDir, entry.name);
+    const fullPath = path.join(targetPath, entry.name);
 
     if (entry.isDirectory()) {
-      files.push(...collectTypeScriptFiles(fullPath));
+      files.push(...collectFiles(fullPath));
       return;
     }
 
-    if (/\.ts$/i.test(entry.name)) {
-      files.push(fullPath);
+    if (entry.isFile()) {
+      files.push(path.resolve(fullPath));
     }
   });
 
-  return files.sort((left, right) => left.localeCompare(right));
+  return files;
 };
 
-const calculateScriptHash = (scriptDir) => {
-  const files = collectTypeScriptFiles(scriptDir);
+const getUniqueSortedFiles = (inputPaths) => {
+  const fileMap = new Map();
+
+  inputPaths.forEach((inputPath) => {
+    collectFiles(inputPath).forEach((filePath) => {
+      fileMap.set(filePath, filePath);
+    });
+  });
+
+  return Array.from(fileMap.values()).sort((left, right) =>
+    normalizePath(left).localeCompare(normalizePath(right))
+  );
+};
+
+const calculateInputHash = (inputPaths) => {
+  const files = getUniqueSortedFiles(inputPaths);
 
   if (files.length === 0) {
     return hashText("empty");
@@ -73,15 +98,44 @@ const calculateScriptHash = (scriptDir) => {
 
   const merged = files
     .map((filePath) => {
-      const relativePath = path
-        .relative(scriptDir, filePath)
-        .replace(/\\/g, "/");
+      const relativePath = normalizePath(path.relative(".", filePath));
       return `${relativePath}:${calculateFileHash(filePath)}`;
     })
     .join("|");
 
   return hashText(merged);
 };
+
+const SHARED_BUILD_INPUTS = [
+  "rollup.config.mjs",
+  "es.config.mjs",
+  "package.json",
+  "pnpm-lock.yaml",
+  "tsconfig.json",
+  "src/init.ts",
+  "src/lib",
+  "src/types",
+];
+
+const getLicenseFile = (srcDir) =>
+  fs.existsSync(`${srcDir}/LICENSE`) ? `${srcDir}/LICENSE` : "LICENSE";
+
+const getScriptHashInputs = ({ appId, script, srcDir, tsconfig }) => {
+  const inputs = [...SHARED_BUILD_INPUTS, srcDir, tsconfig];
+
+  if (appId) {
+    inputs.push(`src/${appId}`);
+  }
+
+  if (script.license) {
+    inputs.push(getLicenseFile(srcDir));
+  }
+
+  return inputs;
+};
+
+const calculateScriptHash = (scriptContext) =>
+  calculateInputHash(getScriptHashInputs(scriptContext));
 
 const loadBuildHashes = () => {
   try {
@@ -173,9 +227,7 @@ const extractCommentsToTop = () => ({
 });
 
 const licenser = (srcDir) => {
-  const licenseDir = fs.existsSync(`${srcDir}/LICENSE`)
-    ? `${srcDir}/LICENSE`
-    : "LICENSE";
+  const licenseDir = getLicenseFile(srcDir);
   return license({
     banner: {
       content: {
@@ -268,10 +320,11 @@ export default (commandLineArgs) => {
   }
 
   const previousBuildHashes = loadBuildHashes();
-  const currentBuildHashes = {};
+  const currentBuildHashes = appFilter ? { ...previousBuildHashes } : {};
 
-  const targetScripts = allScripts.filter(({ script, srcDir, hashKey }) => {
-    const scriptHash = calculateScriptHash(srcDir);
+  const targetScripts = allScripts.filter((scriptContext) => {
+    const { hashKey } = scriptContext;
+    const scriptHash = calculateScriptHash(scriptContext);
     currentBuildHashes[hashKey] = scriptHash;
 
     if (forceBuildAll) {


### PR DESCRIPTION
## 概要

共通依存やビルド設定の変更が、通常の `pnpm build` のビルドスキップ判定に反映されるようにしました。

Closes #30

## 変更内容

- ハッシュ対象をスクリプト配下の `.ts` だけでなく、ビルド出力に影響する共有入力へ拡張
- `rollup.config.mjs`、`es.config.mjs`、`package.json`、`pnpm-lock.yaml`、`tsconfig.json`、`src/init.ts`、`src/lib`、`src/types` を共通入力として追加
- アプリ別スクリプトでは `src/{app}` 全体もハッシュ対象に追加し、app 直下の共有ファイル変更も検知
- `script.license` が有効な場合は、実際に使う `LICENSE` もハッシュ対象に追加
- `--app` 指定時は非対象スクリプトの既存ハッシュ履歴を保持し、次回通常ビルドで余分な再ビルドが起きないように調整

## 影響

既存の CLI や `build-hashes.json` の形は変更していません。初回はハッシュ計算の入力範囲が変わるため、対象スクリプトが再ビルドされます。

## 検証

- `origin/develop` にリベース済み
- `pnpm build --all`
- `pnpm build` で変更なしスキップを確認
- `pnpm build:aeft` で変更なしスキップを確認
- `pnpm build:aeft` 後も `build-hashes.json` に 4 件のキーが残り、直後の通常 `pnpm build` がスキップされることを確認
- 一時的な `src/aeft/shared.ts` 変更で `pnpm build:aeft` が 1 件再ビルドすることを確認
- 一時的な `src/lib/lib.ts` 変更で通常 `pnpm build` が 4 件再ビルドすることを確認
- 一時的な `es.config.mjs` 変更で通常 `pnpm build` が 4 件再ビルドすることを確認
- `pnpm lint`
- `pnpm exec prettier --check rollup.config.mjs`
- `git diff --check`
- サブエージェントレビュー: 最終レビューで指摘なし