### PR TITLE
アプリ別ビルドコマンドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ entry("example", () => {
 pnpm build          # 変更のあるスクリプトをビルド
 pnpm build --all    # 全スクリプトを強制ビルド
 pnpm build --app=aeft  # 特定アプリのみビルド
+pnpm build:aeft     # After Effects のスクリプトのみビルド
 ```
 
 出力先は `dist/{appId}/{ScriptName}/` です。
@@ -130,12 +131,17 @@ pnpm watch
 | `pnpm build`            | 変更のあるスクリプトをビルド     |
 | `pnpm build --all`      | 全スクリプトを強制ビルド         |
 | `pnpm build --app=aeft` | 特定アプリのみビルド             |
+| `pnpm build:aeft`       | After Effects のみビルド         |
+| `pnpm build:ilst`       | Illustrator のみビルド           |
+| `pnpm build:phxs`       | Photoshop のみビルド             |
 | `pnpm watch`            | ファイル変更を監視して自動ビルド |
 | `pnpm lint`             | ESLint でコード検査              |
 | `pnpm format`           | Prettier でコード整形            |
 | `pnpm new`              | 新規スクリプト追加               |
 | `pnpm add-app`          | 新規アプリ追加                   |
 | `pnpm clean`            | ビルドハッシュをクリーンアップ   |
+
+`pnpm add-app -- --app=<appId>` で正式対応アプリを追加すると、`pnpm build:<appId>` も自動で追加されます。
 
 ## テスト / Test
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -72,7 +72,11 @@ pnpm build
 
 ```bash
 pnpm build --app=aeft
+pnpm build:aeft
 ```
+
+`pnpm build:aeft` は `pnpm build --app=aeft` と同じく、After Effects 向けスクリプトだけをビルドする短い別名です。
+Illustrator は `pnpm build:ilst`、Photoshop は `pnpm build:phxs` を使えます。
 
 ### 新しいアプリを追加
 
@@ -81,6 +85,7 @@ pnpm add-app -- --app=idsn
 ```
 
 追加できるのは `aeft`, `ilst`, `phxs`, `idsn`, `ppro`, `anmt`, `audt` の正式対応アプリのみです。
+追加したアプリには `pnpm build:<appId>` も自動で追加されます。
 
 ## ディレクトリ構造
 

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -203,22 +203,26 @@ pnpm add-app -- --app=idsn
 - `src/{app}/lib/.gitkeep`
 - `src/{app}/example/index.ts`
 - `es.config.mjs` に `scripts.{app}` キーを追加し、`example` を `build: true`, `license: true` で登録
+- `package.json` に `build:<appId>` コマンドを追加
 
 既存の `src/{appId}` または `es.config.mjs` の `scripts.{appId}` と衝突する場合は、ファイルを生成せずに停止する。
 
 ## 開発コマンド
 
-| コマンド                | 説明                               |
-| ----------------------- | ---------------------------------- |
-| `pnpm build`            | 変更のあるスクリプトをビルド       |
-| `pnpm build --all`      | 全スクリプトを強制ビルド           |
-| `pnpm build --app=aeft` | 特定アプリのスクリプトのみビルド   |
-| `pnpm watch`            | ファイル変更を監視して自動ビルド   |
-| `pnpm lint`             | ESLint でコード検査                |
-| `pnpm format`           | Prettier でコード整形              |
-| `pnpm new`              | 新規スクリプト追加（対話式 / CLI） |
-| `pnpm add-app`          | 新規アプリスキャフォールディング   |
-| `pnpm clean`            | ビルドハッシュをクリーンアップ     |
+| コマンド                | 説明                                 |
+| ----------------------- | ------------------------------------ |
+| `pnpm build`            | 変更のあるスクリプトをビルド         |
+| `pnpm build --all`      | 全スクリプトを強制ビルド             |
+| `pnpm build --app=aeft` | 特定アプリのスクリプトのみビルド     |
+| `pnpm build:aeft`       | After Effects のスクリプトのみビルド |
+| `pnpm build:ilst`       | Illustrator のスクリプトのみビルド   |
+| `pnpm build:phxs`       | Photoshop のスクリプトのみビルド     |
+| `pnpm watch`            | ファイル変更を監視して自動ビルド     |
+| `pnpm lint`             | ESLint でコード検査                  |
+| `pnpm format`           | Prettier でコード整形                |
+| `pnpm new`              | 新規スクリプト追加（対話式 / CLI）   |
+| `pnpm add-app`          | 新規アプリスキャフォールディング     |
+| `pnpm clean`            | ビルドハッシュをクリーンアップ       |
 
 ## 型情報について
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Multi-app ExtendScript TypeScript template for Adobe After Effects, Illustrator, Photoshop, and more",
   "scripts": {
     "build": "rollup -c",
+    "build:aeft": "rollup -c --app=aeft",
+    "build:ilst": "rollup -c --app=ilst",
+    "build:phxs": "rollup -c --app=phxs",
     "clean": "node ./scripts/cleanBuildHashes.mjs",
     "watch": "rollup -c -w",
     "lint": "eslint .",

--- a/scripts/addApp.mjs
+++ b/scripts/addApp.mjs
@@ -18,6 +18,7 @@ const __dirname = path.dirname(__filename);
 
 const projectRoot = path.resolve(__dirname, "..");
 const ES_CONFIG_PATH = path.resolve(projectRoot, "es.config.mjs");
+const PACKAGE_JSON_PATH = path.resolve(projectRoot, "package.json");
 const SRC_DIR = path.resolve(projectRoot, "src");
 const EXAMPLE_SCRIPT = {
   name: "example",
@@ -98,6 +99,8 @@ const I18N = {
     },
     done: (app) => `完了: src/${app}/ のスキャフォールディングが完了しました。`,
     configUpdated: (app) => `es.config.mjs に scripts.${app} を追加しました。`,
+    packageScriptUpdated: (app) =>
+      `package.json に build:${app} を追加しました。`,
   },
   en: {
     prompt: {
@@ -122,6 +125,7 @@ const I18N = {
     },
     done: (app) => `Done: Scaffolding for src/${app}/ complete.`,
     configUpdated: (app) => `Added scripts.${app} to es.config.mjs.`,
+    packageScriptUpdated: (app) => `Added build:${app} to package.json.`,
   },
 };
 
@@ -278,6 +282,64 @@ async function updateEsConfig(appId, content) {
   await writeFile(ES_CONFIG_PATH, newContent, { encoding: "utf8" });
 }
 
+function shouldInsertAfterBuildScript(currentKey, nextKey) {
+  const isBuildKey = currentKey === "build" || currentKey.startsWith("build:");
+  const nextIsBuildKey = nextKey && nextKey.startsWith("build:");
+  return isBuildKey && !nextIsBuildKey;
+}
+
+function addBuildScriptAlias(scripts, appId) {
+  const scriptName = `build:${appId}`;
+  if (Object.prototype.hasOwnProperty.call(scripts, scriptName)) {
+    return { scripts, added: false };
+  }
+
+  const entries = Object.entries(scripts);
+  const nextScripts = {};
+  let inserted = false;
+
+  for (let i = 0; i < entries.length; i++) {
+    const [key, value] = entries[i];
+    nextScripts[key] = value;
+
+    const nextKey = entries[i + 1]?.[0] || null;
+    if (!inserted && shouldInsertAfterBuildScript(key, nextKey)) {
+      nextScripts[scriptName] = `rollup -c --app=${appId}`;
+      inserted = true;
+    }
+  }
+
+  if (!inserted) {
+    nextScripts[scriptName] = `rollup -c --app=${appId}`;
+  }
+
+  return { scripts: nextScripts, added: true };
+}
+
+async function updatePackageScripts(appId) {
+  const content = await readFile(PACKAGE_JSON_PATH, { encoding: "utf8" });
+  const packageJson = JSON.parse(content);
+  const scripts =
+    packageJson.scripts && typeof packageJson.scripts === "object"
+      ? packageJson.scripts
+      : {};
+  const result = addBuildScriptAlias(scripts, appId);
+
+  if (!result.added) {
+    return false;
+  }
+
+  packageJson.scripts = result.scripts;
+  await writeFile(
+    PACKAGE_JSON_PATH,
+    JSON.stringify(packageJson, null, 2) + "\n",
+    {
+      encoding: "utf8",
+    }
+  );
+  return true;
+}
+
 async function scaffold(appId) {
   const { appDir, esConfigContent } = await validateScaffold(appId);
 
@@ -318,7 +380,11 @@ async function scaffold(appId) {
 
   // es.config.mjs 更新
   await updateEsConfig(appId, esConfigContent);
+  const packageScriptAdded = await updatePackageScripts(appId);
   execSync(`prettier --write "${ES_CONFIG_PATH}"`, { stdio: "inherit" });
+  if (packageScriptAdded) {
+    console.log(L.packageScriptUpdated(appId));
+  }
   console.log(L.configUpdated(appId));
   console.log(L.done(appId));
 }


### PR DESCRIPTION
## 概要

- `pnpm build:aeft` / `pnpm build:ilst` / `pnpm build:phxs` を追加しました。
- `pnpm add-app -- --app=<appId>` 実行時に、追加アプリ用の `pnpm build:<appId>` も自動追加するようにしました。
- README と主要ドキュメントにアプリ別ビルドコマンドの説明を追加しました。

## 影響

- 既存の `pnpm build --app=<appId>` はそのまま使えます。
- 新しい `build:<appId>` は、指定アプリの増分ビルドを短く実行する別名です。
- 追加アプリの作成時も、既存の `build:*` コマンド群の近くに別名が追加されます。

## 確認

- `pnpm format`
- `pnpm lint`
- `pnpm build:aeft`
- `pnpm build:ilst`
- `pnpm build:phxs`
- `pnpm build --app=aeft`
- 検証用コピーで `pnpm add-app -- --app=idsn` を実行し、`build:idsn` が追加されることを確認
- `git diff --check`

Closes #18