### PR TITLE
fix: Math.round ポリフィルを無効化

### DIFF
--- a/src/lib/polyfills/es6-shim.js
+++ b/src/lib/polyfills/es6-shim.js
@@ -2512,17 +2512,25 @@
   ].every(function (num) {
     return Math.round(num) === num;
   });
-  defineProperty(
-    Math,
-    "round",
-    function round(x) {
-      var floor = _floor(x);
-      var ceil = floor === -1 ? -0 : floor + 1;
-      return x - floor < 0.5 ? floor : ceil;
-    },
-    !roundHandlesBoundaryConditions || !roundDoesNotIncreaseIntegers
-  );
-  Value.preserveToString(Math.round, origMathRound);
+  // extendscript-ts-template local modification:
+  // keep ExtendScript's native Math.round instead of applying es6-shim's polyfill.
+  var enableMathRoundPolyfill = false;
+  if (
+    enableMathRoundPolyfill &&
+    (!roundHandlesBoundaryConditions || !roundDoesNotIncreaseIntegers)
+  ) {
+    defineProperty(
+      Math,
+      "round",
+      function round(x) {
+        var floor = _floor(x);
+        var ceil = floor === -1 ? -0 : floor + 1;
+        return x - floor < 0.5 ? floor : ceil;
+      },
+      !roundHandlesBoundaryConditions || !roundDoesNotIncreaseIntegers
+    );
+    Value.preserveToString(Math.round, origMathRound);
+  }
 
   var origImul = Math.imul;
   if (Math.imul(0xffffffff, 5) !== -5) {

--- a/src/tests/index.ts
+++ b/src/tests/index.ts
@@ -248,6 +248,13 @@ import "../init";
     );
   });
 
+  run("Math.round", () => {
+    assertEq(Math.round(0), 0, "Math.round(0) is 0");
+    assertEq(Math.round(0.5), 1, "Math.round(0.5) is 1");
+    assert(Object.is(Math.round(-0.5), -0), "Math.round(-0.5) is -0");
+    assert(Object.is(Math.round(-0), -0), "Math.round(-0) is -0");
+  });
+
   run("Object.assign", () => {
     const target: any = { a: 1 };
     const assigned = Object.assign(target, { b: 2 }, { c: 3 });


### PR DESCRIPTION
## 変更内容

- `es6-shim` による `Math.round` の上書きを無効化
- `Math.round(-0.5)` と `Math.round(-0)` が `-0` を返すことをテストに追加

## 背景

ExtendScript のネイティブ `Math.round` を `es6-shim` が置き換えると、負のゼロを含む境界値で実行環境の期待値とずれる可能性があるため、配布用リポジトリにも個人用リポジトリで確認済みの回避策を移植します。

## 検証

- `pn lint`
- `pn build --all`
