### PR TITLE
feat: 差分ビルドの依存判定を細分化

### DIFF
--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -224,6 +224,20 @@ pnpm add-app -- --app=idsn
 | `pnpm add-app`          | 新規アプリスキャフォールディング     |
 | `pnpm clean`            | ビルドハッシュをクリーンアップ       |
 
+## 差分ビルドの判定
+
+`pnpm build` は、各スクリプトの `index.ts` から相対 `import` / `export ... from`
+で到達するファイルと、ビルド設定ファイルのハッシュを使って再ビルド対象を判定する。
+同じ `src/{appId}` 配下にある別スクリプトを変更しても、そのスクリプトを import していない
+他のスクリプトは再ビルド対象にならない。
+
+`rollup.config.mjs`、`es.config.mjs`、`package.json`、`pnpm-lock.yaml`、`tsconfig.json`、
+対象アプリの `tsconfig.json` を変更した場合は、該当するビルド対象のハッシュが変わる。
+`src/init.ts`、`src/lib/`、`src/{appId}/lib/` は、スクリプトから import で到達している場合だけ、
+そのスクリプトのハッシュに含まれる。
+`src/types/` は全スクリプト、`src/{appId}/types/` は該当アプリのスクリプトで使える ambient 型定義
+として扱うため、該当するビルド対象のハッシュに含まれる。
+
 ## 型情報について
 
 [Types-for-Adobe](https://github.com/docsforadobe/Types-for-Adobe) を使用。

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -42,6 +42,10 @@ const hashText = (text) => {
 
 const normalizePath = (filePath) => filePath.replace(/\\/g, "/");
 
+const IMPORT_RESOLVE_EXTENSIONS = [".ts", ".js", ".d.ts"];
+const IMPORT_SPECIFIER_PATTERN =
+  /\b(?:import|export)\s+(?:type\s+)?(?:[^'"]*?\s+from\s+)?["']([^"']+)["']|import\s*\(\s*["']([^"']+)["']\s*\)/g;
+
 const collectFiles = (targetPath) => {
   if (!fs.existsSync(targetPath)) {
     return [];
@@ -112,20 +116,118 @@ const SHARED_BUILD_INPUTS = [
   "package.json",
   "pnpm-lock.yaml",
   "tsconfig.json",
-  "src/init.ts",
-  "src/lib",
-  "src/types",
 ];
 
 const getLicenseFile = (srcDir) =>
   fs.existsSync(`${srcDir}/LICENSE`) ? `${srcDir}/LICENSE` : "LICENSE";
 
-const getScriptHashInputs = ({ appId, script, srcDir, tsconfig }) => {
-  const inputs = [...SHARED_BUILD_INPUTS, srcDir, tsconfig];
+const getAmbientTypeInputs = (appId) => {
+  const inputs = ["src/types"];
 
   if (appId) {
-    inputs.push(`src/${appId}`);
+    inputs.push(`src/${appId}/types`);
   }
+
+  return inputs;
+};
+
+const stripComments = (source) =>
+  source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+const getRelativeImportSpecifiers = (filePath) => {
+  const source = stripComments(fs.readFileSync(filePath, "utf8"));
+  const specifiers = [];
+
+  IMPORT_SPECIFIER_PATTERN.lastIndex = 0;
+
+  let match = IMPORT_SPECIFIER_PATTERN.exec(source);
+  while (match) {
+    const specifier = match[1] || match[2];
+
+    if (specifier && specifier.startsWith(".")) {
+      specifiers.push(specifier);
+    }
+
+    match = IMPORT_SPECIFIER_PATTERN.exec(source);
+  }
+
+  return specifiers;
+};
+
+const getImportCandidates = (importBasePath) => {
+  const candidates = [];
+
+  if (path.extname(importBasePath)) {
+    candidates.push(importBasePath);
+  } else {
+    IMPORT_RESOLVE_EXTENSIONS.forEach((extension) => {
+      candidates.push(`${importBasePath}${extension}`);
+    });
+  }
+
+  IMPORT_RESOLVE_EXTENSIONS.forEach((extension) => {
+    candidates.push(path.join(importBasePath, `index${extension}`));
+  });
+
+  return candidates;
+};
+
+const resolveRelativeImport = (fromFilePath, specifier) => {
+  const importBasePath = path.resolve(path.dirname(fromFilePath), specifier);
+
+  return (
+    getImportCandidates(importBasePath).find((candidate) => {
+      if (!fs.existsSync(candidate)) {
+        return false;
+      }
+
+      return fs.statSync(candidate).isFile();
+    }) || null
+  );
+};
+
+const canReadImports = (filePath) =>
+  IMPORT_RESOLVE_EXTENSIONS.includes(path.extname(filePath));
+
+const collectImportDependencyFiles = (entryFile) => {
+  const files = new Map();
+
+  const visit = (filePath) => {
+    const resolvedFile = path.resolve(filePath);
+
+    if (files.has(resolvedFile) || !fs.existsSync(resolvedFile)) {
+      return;
+    }
+
+    files.set(resolvedFile, resolvedFile);
+
+    if (!canReadImports(resolvedFile)) {
+      return;
+    }
+
+    getRelativeImportSpecifiers(resolvedFile).forEach((specifier) => {
+      const importedFile = resolveRelativeImport(resolvedFile, specifier);
+
+      if (importedFile) {
+        visit(importedFile);
+      }
+    });
+  };
+
+  visit(entryFile);
+
+  return Array.from(files.values()).sort((left, right) =>
+    normalizePath(left).localeCompare(normalizePath(right))
+  );
+};
+
+const getScriptHashInputs = ({ appId, script, srcDir, tsconfig }) => {
+  const inputs = [
+    ...SHARED_BUILD_INPUTS,
+    tsconfig,
+    ...getAmbientTypeInputs(appId),
+    ...collectImportDependencyFiles(`${srcDir}/index.ts`),
+  ];
 
   if (script.license) {
     inputs.push(getLicenseFile(srcDir));
@@ -288,6 +390,8 @@ export default (commandLineArgs) => {
     for (const [appId, scripts] of Object.entries(config.scripts)) {
       if (appFilter && appId !== appFilter) continue;
       for (const script of scripts) {
+        if (script.build === false) continue;
+
         allScripts.push({
           appId,
           script,
@@ -303,6 +407,8 @@ export default (commandLineArgs) => {
   // common スクリプト（アプリ非依存）
   if (config.common && !appFilter) {
     for (const script of config.common) {
+      if (script.build === false) continue;
+
       allScripts.push({
         appId: null,
         script,


### PR DESCRIPTION
## 変更内容

- 差分ビルドのハッシュ入力を `src/{appId}` 全体から、各 `index.ts` の相対 `import` / `export ... from` で到達できるファイルへ細分化
- `src/types` と `src/{appId}/types` は ambient 型定義としてハッシュ対象に維持
- `script.build === false` のスクリプトをビルド対象から除外
- `docs/project-overview.md` に差分ビルドの判定ルールを追記

## 背景

配布用リポジトリには共通依存をビルドハッシュに含める実装が入っていますが、現状は `src/{appId}` や `src/lib` 全体が広く対象になり、同じアプリ配下の無関係なスクリプト変更でも再ビルドされます。

この変更では、共通依存を見落とさないまま、実際に import/export で到達する依存だけで再ビルド対象を判断できるようにします。

## 検証

- `pn lint`
- `pn build --all`
- `pn build` で変更なしスキップを確認
