### PR TITLE
fix: example の alert を ScriptUI ダイアログに置換

### DIFF
--- a/src/aeft/example/index.ts
+++ b/src/aeft/example/index.ts
@@ -4,6 +4,13 @@ import "../../init";
 // libから必要な関数をimportします。
 import { entry } from "../lib/lib";
 
+const showMessage = (title: string, message: string) => {
+  const win = new Window("dialog", title);
+  win.add("statictext", undefined, message, { multiline: true });
+  win.add("button", undefined, "OK", { name: "ok" });
+  win.show();
+};
+
 // スクリプトはすべてentryの中に書いてください
 // アロー関数が使えるようになった
 entry("example", () => {
@@ -17,32 +24,32 @@ entry("example", () => {
   if (selected.length === 0) return;
 
   // Array.mapとArray.joinが使えるようになった
-  alert(selected.map((l) => l.name).join("\n"));
+  const selectedNames = selected.map((l) => l.name).join("\n");
 
   const names: string[] = [];
   // for...ofが使えるようになった
   for (const layer of selected) {
     names.push(layer.name);
   }
-  alert(names.join("\n"));
-
-  // テンプレートリテラルが使えるようになった
-  alert(`選択中のレイヤー数: ${selected.length}`);
 
   // Array.reduceが使えるようになった
   const totalOpacity = selected.reduce(
     (sum, layer) => sum + layer.opacity.value,
     0
   );
-  alert(`選択中のレイヤーの不透明度の合計: ${totalOpacity}`);
 
-  const hoge = () => {
+  const getOpacityStats = () => {
     return [totalOpacity, totalOpacity / selected.length];
   };
   // 分割代入が使えるようになった
-  const [_, averageOpacity] = hoge();
+  const [_, averageOpacity] = getOpacityStats();
 
-  alert(
-    `選択中のレイヤーの不透明度の合計: ${totalOpacity}\n平均: ${averageOpacity}`
+  // テンプレートリテラルが使えるようになった
+  showMessage(
+    "example",
+    `選択中のレイヤー数: ${selected.length}\n\n` +
+      `Array.map の結果:\n${selectedNames}\n\n` +
+      `for...of の結果:\n${names.join("\n")}\n\n` +
+      `不透明度の合計: ${totalOpacity}\n平均: ${averageOpacity}`
   );
 });

--- a/src/ilst/example/index.ts
+++ b/src/ilst/example/index.ts
@@ -1,6 +1,13 @@
 import "../../init";
 import { entry } from "../lib/lib";
 
+const showMessage = (title: string, message: string) => {
+  const win = new Window("dialog", title);
+  win.add("statictext", undefined, message, { multiline: true });
+  win.add("button", undefined, "OK", { name: "ok" });
+  win.show();
+};
+
 entry("example", () => {
   const doc = app.activeDocument;
   if (!doc) return;
@@ -9,5 +16,5 @@ entry("example", () => {
   if (!selected || selected.length === 0) return;
 
   const names = selected.map((item) => item.name || item.typename);
-  alert(`選択中のアイテム:\n${names.join("\n")}`);
+  showMessage("example", `選択中のアイテム:\n${names.join("\n")}`);
 });

--- a/src/phxs/example/index.ts
+++ b/src/phxs/example/index.ts
@@ -1,10 +1,17 @@
 import "../../init";
 import { entry } from "../lib/lib";
 
+const showMessage = (title: string, message: string) => {
+  const win = new Window("dialog", title);
+  win.add("statictext", undefined, message, { multiline: true });
+  win.add("button", undefined, "OK", { name: "ok" });
+  win.show();
+};
+
 entry("example", () => {
   const doc = app.activeDocument;
   if (!doc) return;
 
   const layer = doc.activeLayer;
-  alert(`アクティブレイヤー: ${layer.name}`);
+  showMessage("example", `アクティブレイヤー: ${layer.name}`);
 });


### PR DESCRIPTION
## 変更内容

- After Effects / Illustrator / Photoshop の example から `alert()` を削除
- ScriptUI の `new Window("dialog", ...)` を使う `showMessage` ヘルパーへ置換
- After Effects example の複数 alert は1つの結果ダイアログに統合

## 背景

このリポジトリではユーザー表示や確認に `alert()` / `confirm()` を使わず、ScriptUI の `new Window()` を使う方針にしています。サンプルコードも同じ方針に合わせます。

## 検証

- `rg -n "\\balert\\s*\\(" src/aeft/example src/ilst/example src/phxs/example` で残存なしを確認
- `pn lint`
- `pn build --all`
